### PR TITLE
Split setupDevice, add exports setupSerialNumber, getSetupMode, getSetupModeForSerialNumber

### DIFF
--- a/src/jprogFunc.js
+++ b/src/jprogFunc.js
@@ -134,15 +134,35 @@ function verifySerialPortAvailable(device) {
     });
 }
 
+/**
+ * Calls nrfjprog.open() with the serial number of the given device
+ *
+ * @param {object} device Device object, ref. nrf-device-lister.
+ * @returns {Promise} Resolves to the given device, or rejects with the nrfjprog error
+ */
 function openJLink(device) {
+    if (!device.traits.includes('jlink')) {
+        return Promise.reject(new Error('Device with serial number ' +
+            device.serialNumber + ' is not a jlink probe'));
+    }
     return new Promise((resolve, reject) => {
-        nrfjprog.open(parseSerial(device.serialNumber), err => (err ? reject(err) : resolve()));
+        nrfjprog.open(parseSerial(device.serialNumber), err => (err ? reject(err) : resolve(device)));
     });
 }
 
+/**
+ * Calls nrfjprog.close() with the serial number of the given device
+ *
+ * @param {object} device Device object, ref. nrf-device-lister.
+ * @returns {Promise} Resolves to the given device, or rejects with the nrfjprog error
+ */
 function closeJLink(device) {
+    if (!device.traits.includes('jlink')) {
+        return Promise.reject(new Error('Device with serial number ' +
+            device.serialNumber + ' is not a jlink probe'));
+    }
     return new Promise((resolve, reject) => {
-        nrfjprog.close(parseSerial(device.serialNumber), err => (err ? reject(err) : resolve()));
+        nrfjprog.close(parseSerial(device.serialNumber), err => (err ? reject(err) : resolve(device)));
     });
 }
 

--- a/src/jprogFunc.js
+++ b/src/jprogFunc.js
@@ -142,11 +142,13 @@ function verifySerialPortAvailable(device) {
  */
 function openJLink(device) {
     if (!device.traits.includes('jlink')) {
-        return Promise.reject(new Error('Device with serial number ' +
-            device.serialNumber + ' is not a jlink probe'));
+        return Promise.reject(new Error(`Device with serial number ${
+            device.serialNumber} is not a jlink probe`));
     }
     return new Promise((resolve, reject) => {
-        nrfjprog.open(parseSerial(device.serialNumber), err => (err ? reject(err) : resolve(device)));
+        nrfjprog.open(parseSerial(device.serialNumber),
+                      err => (err ? reject(err) : resolve(device))
+        );
     });
 }
 
@@ -158,11 +160,13 @@ function openJLink(device) {
  */
 function closeJLink(device) {
     if (!device.traits.includes('jlink')) {
-        return Promise.reject(new Error('Device with serial number ' +
-            device.serialNumber + ' is not a jlink probe'));
+        return Promise.reject(new Error(`Device with serial number ${
+            device.serialNumber} is not a jlink probe`));
     }
     return new Promise((resolve, reject) => {
-        nrfjprog.close(parseSerial(device.serialNumber), err => (err ? reject(err) : resolve(device)));
+        nrfjprog.close(parseSerial(device.serialNumber),
+                       err => (err ? reject(err) : resolve(device))
+        );
     });
 }
 

--- a/src/setupDevice.js
+++ b/src/setupDevice.js
@@ -202,7 +202,7 @@ function parseFirmwareImage(firmware) {
  * then performs the DFU operation.
  * This causes the device to be detached, so finally it waits for it to be attached again.
  *
- * @param {object} device nrf-device-lister's device
+ * @param {object} dev nrf-device-lister's device
  * @param {object} dfu configuration object for performing the DFU
  * @returns {Promise} resolved to prepared device
  */
@@ -212,9 +212,8 @@ async function prepareInDFUBootloader(dev, dfu) {
     if (!isDeviceInDFUBootloader(device)) {
         const usbdev = device.usb.device;
         debug('Switching to bootloader mode.');
-        const newSerNr = await predictSerialNumberAfterReset(usbdev);
-        debug('Serial number after reset should be:', newSerNr);
-        device = await detachAndWaitFor(usbdev, getDFUInterfaceNumber(usbdev), newSerNr);
+        debug('Serial number after reset should be:', device.serialNumber);
+        device = await detachAndWaitFor(usbdev, getDFUInterfaceNumber(usbdev), device.serialNumber);
     }
 
     const { comName } = device.serialport;


### PR DESCRIPTION
This splits part of the `setupDevice()` functionality into `getSetupMode()`. This allows for consumers of this library to **not** pass promise-returning callbacks, and know whether to ask for a DFU image or not.

Also implements `setupSerialNumber` and `getSetupModeForSerialNumber`, to allow library consumers to set up a device given only its serial number. This is useful in scenarios where storing and passing around mutable data structures is undesirable.