### PR TITLE
Sanity checks for USB detach result

### DIFF
--- a/src/dfuTrigger.js
+++ b/src/dfuTrigger.js
@@ -142,7 +142,7 @@ const sendDetachRequest = openDecorator((usbdev, interfaceNumber) => (
         usbdev.controlTransfer(
             ReqTypeOUT, DFU_DETACH_REQUEST, 0, interfaceNumber, detachReqBuf,
             (err, data) => {
-                // If the detach is sucessfull, the target device will reboot
+                // If the detach is successful, the target device will reboot
                 // before sending a response, so the expected result is that
                 // the control transfer will stall.
                 if (err &&

--- a/src/dfuTrigger.js
+++ b/src/dfuTrigger.js
@@ -86,16 +86,16 @@ function assertDfuTriggerInterface(usbdev, interfaceNumber) {
     if (!(usbdev.interfaces instanceof Array)) {
         throw new Error('USB Device must be open before performing any operations on the DFU trigger interface');
     }
-    const iface = usbdev.interfaces[interfaceNumber]
+    const iface = usbdev.interfaces[interfaceNumber];
     if (!iface) {
-        throw new Error('Interface number ' + interfaceNumber + ' does not exist on USB device; cannot perform DFU trigger operation.');
+        throw new Error(`Interface number ${interfaceNumber} does not exist on USB device; cannot perform DFU trigger operation.`);
     }
 
     if (iface.descriptor.bInterfaceClass !== 255 ||
         iface.descriptor.bInterfaceSubClass !== 1 ||
         iface.descriptor.bInterfaceProtocol !== 1
     ) {
-        throw new Error('Interface number ' + interfaceNumber + ' does not look like a DFU trigger interface; cannot perform DFU trigger operation.');
+        throw new Error(`Interface number ${interfaceNumber} does not look like a DFU trigger interface; cannot perform DFU trigger operation.`);
     }
 }
 
@@ -167,17 +167,15 @@ const getDfuInfo = openDecorator((usbdev, interfaceNumber) => (
 const sendDetachRequest = openDecorator((usbdev, interfaceNumber) => (
     new Promise((resolve, reject) => {
         assertDfuTriggerInterface(usbdev, interfaceNumber);
-        debug('Claiming interface ' + interfaceNumber);
+        debug(`Claiming interface ${interfaceNumber}`);
         usbdev.interfaces[interfaceNumber].claim();
         debug('Sending DFU detach request ');
         usbdev.controlTransfer(
             ReqTypeOUT, DFU_DETACH_REQUEST, 0, interfaceNumber, detachReqBuf,
             (err, data) => {
-
-                debug('Releasing interface ' + interfaceNumber);
-                usbdev.interfaces[interfaceNumber].release(err2=>{
-                    if (err2) {reject(err2);}
-
+                debug(`Releasing interface ${interfaceNumber}`);
+                usbdev.interfaces[interfaceNumber].release(err2 => {
+                    if (err2) { reject(err2); }
 
                     // If the detach is successful, the target device will reboot
                     // before sending a response, so the expected result is that
@@ -197,7 +195,6 @@ const sendDetachRequest = openDecorator((usbdev, interfaceNumber) => (
                         reject(new Error('USB DFU detach request sent, but device does not seem to have rebooted'));
                     }
                 });
-
             }
         );
     })
@@ -213,7 +210,7 @@ const sendDetachRequest = openDecorator((usbdev, interfaceNumber) => (
  */
 export function detach(usbdev, timeout = 5000) {
     debug('detach', timeout);
-    return new Promise((resolve, reject)=>{
+    return new Promise((resolve, reject) => {
         function checkDetachment(detachedDev) {
             if (usbdev === detachedDev) {
                 debug('Detachment successful');
@@ -223,16 +220,16 @@ export function detach(usbdev, timeout = 5000) {
             }
         }
 
-        const timeoutId = setTimeout(()=>{
+        const timeoutId = setTimeout(() => {
             debug('Timeout when waiting for USB detach event');
             usb.removeListener('detach', checkDetachment);
-            reject(new Error('USB detach request sent, timeout while waiting for device reboot'))
+            reject(new Error('USB detach request sent, timeout while waiting for device reboot'));
         }, timeout);
 
         usb.on('detach', checkDetachment);
         const dfuIface = getDFUInterfaceNumber(usbdev);
 
-        sendDetachRequest(usbdev, dfuIface).catch((err)=>{
+        sendDetachRequest(usbdev, dfuIface).catch(err => {
             debug('Error when sending detach request');
             clearTimeout(timeoutId);
             usb.removeListener('detach', checkDetachment);

--- a/src/dfuTrigger.js
+++ b/src/dfuTrigger.js
@@ -167,29 +167,79 @@ const getDfuInfo = openDecorator((usbdev, interfaceNumber) => (
 const sendDetachRequest = openDecorator((usbdev, interfaceNumber) => (
     new Promise((resolve, reject) => {
         assertDfuTriggerInterface(usbdev, interfaceNumber);
+        debug('Claiming interface ' + interfaceNumber);
+        usbdev.interfaces[interfaceNumber].claim();
+        debug('Sending DFU detach request ');
         usbdev.controlTransfer(
             ReqTypeOUT, DFU_DETACH_REQUEST, 0, interfaceNumber, detachReqBuf,
             (err, data) => {
-                // If the detach is successful, the target device will reboot
-                // before sending a response, so the expected result is that
-                // the control transfer will stall.
-                if (err &&
-                    err.errno === usb.LIBUSB_TRANSFER_STALL &&
-                    err.message === 'LIBUSB_TRANSFER_STALL') {
-                    resolve();
-                } else if (err &&
-                    err.errno === usb.LIBUSB_ERROR_IO &&
-                    err.message === 'LIBUSB_ERROR_IO') {
-                    // This edge case only happens when using the "libusb" kernel
-                    // driver on win32 (not "winusb", not "libusbk")
-                    resolve();
-                } else {
-                    reject(new Error('USB DFU detach request sent, but device does not seem to have rebooted'));
-                }
+
+                debug('Releasing interface ' + interfaceNumber);
+                usbdev.interfaces[interfaceNumber].release(err2=>{
+                    if (err2) {reject(err2);}
+
+
+                    // If the detach is successful, the target device will reboot
+                    // before sending a response, so the expected result is that
+                    // the control transfer will stall.
+                    if (err &&
+                        err.errno === usb.LIBUSB_TRANSFER_STALL &&
+                        err.message === 'LIBUSB_TRANSFER_STALL') {
+                        resolve();
+                    } else if (err &&
+                        err.errno === usb.LIBUSB_ERROR_IO &&
+                        err.message === 'LIBUSB_ERROR_IO') {
+                        // This edge case only happens when using the "libusb" kernel
+                        // driver on win32 (not "winusb", not "libusbk")
+                        resolve();
+                    } else {
+                        debug('DFU detach request did not stall as expected');
+                        reject(new Error('USB DFU detach request sent, but device does not seem to have rebooted'));
+                    }
+                });
+
             }
         );
     })
 ));
+
+/**
+ * Sends a detach request to a nRF USB device running in application mode,
+ * and waits until it reboots out of application mode.
+ *
+ * @param {Device} usbdev Instance of USB's Device
+ * @param {number} timeout Timeout, in milliseconds, to wait for device detachment
+ * @return {Promise} Resolves to undefined
+ */
+export function detach(usbdev, timeout = 5000) {
+    debug('detach', timeout);
+    return new Promise((resolve, reject)=>{
+        function checkDetachment(detachedDev) {
+            if (usbdev === detachedDev) {
+                debug('Detachment successful');
+                clearTimeout(timeoutId);
+                usb.removeListener('detach', checkDetachment);
+                resolve();
+            }
+        }
+
+        const timeoutId = setTimeout(()=>{
+            debug('Timeout when waiting for USB detach event');
+            usb.removeListener('detach', checkDetachment);
+            reject(new Error('USB detach request sent, timeout while waiting for device reboot'))
+        }, timeout);
+
+        usb.on('detach', checkDetachment);
+        const dfuIface = getDFUInterfaceNumber(usbdev);
+
+        sendDetachRequest(usbdev, dfuIface).catch((err)=>{
+            debug('Error when sending detach request');
+            clearTimeout(timeoutId);
+            usb.removeListener('detach', checkDetachment);
+            reject(err);
+        });
+    });
+}
 
 export {
     getDFUInterfaceNumber,

--- a/src/setupDevice.js
+++ b/src/setupDevice.js
@@ -45,6 +45,7 @@ const {
     getDFUInterfaceNumber,
     getSemVersion,
     sendDetachRequest,
+    detach,
 } = dfuTrigger;
 
 const {
@@ -131,7 +132,7 @@ export function waitForDevice(serialNumber, retry = 0, lister = new DeviceLister
  */
 export function detachAndWaitFor(usbdev, interfaceNumber, serialNumber) {
     debug('Sending detach, will wait for attach');
-    return sendDetachRequest(usbdev, interfaceNumber)
+    return detach(usbdev)
         .then(() => waitForDevice(serialNumber));
 }
 


### PR DESCRIPTION
This is meant to throw an error in any cases where the target devkit does **not** reboot after a detach request. There are two main cases:

- The USB DFU detach request does **not** stall (as expected)
- The `usb` module does **not** fire a `detach` event with the expected device