### PR TITLE
Edit default sdReq for SoftDevice init packet

### DIFF
--- a/src/setupDevice.js
+++ b/src/setupDevice.js
@@ -202,7 +202,7 @@ async function prepareInDFUBootloader(device, dfu) {
             .set('hashType', HashType.SHA256)
             .set('hash', calculateSHA256Hash(firmwareImage))
             .set('sdSize', firmwareImage.length)
-            .set('sdReq', params.sdReq || [0xFE]);
+            .set('sdReq', params.sdReq || []);
 
         const packet = createInitPacketUint8Array(initPacketParams);
 


### PR DESCRIPTION
I am not sure why `0xFE` was given as a default `sdReq` for the SoftDevice init packet. It makes the DFU fail when trying to DFU s132_softdevice_3.0.0 and connectivity application.

I think it makes most sense to leave the `sdReq` for the SoftDevice init packet empty if it is not explicitly provided. When leaving it empty, the DFU seems to work fine regardless of what SoftDevice version is present on the device from before.