### PR TITLE
 Check for traits when waiting for device

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nrf-device-setup",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Common USB/serialport/jlink device actions to check/program nRF devices",
   "main": "dist/index.js",
   "license": "BSD-3",


### PR DESCRIPTION
When doing a reenumeration in `waitForDevice` right after doing a DFU, the device is found, but it only has the serialport trait. Also, the serialport shows up as "Nordic_Semiconductor_Open_DFU_Bootloader". I
suspect that the device is still in DFU mode and has not had time to reboot into application mode yet.

To be sure that the device has actually rebooted into application mode after DFU, we check that it has the nordicUsb and nordicDfu traits.