### PR TITLE
Feature/validate serialport

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nrf-device-setup",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Common USB/serialport/jlink device actions to check/program nRF devices",
   "main": "dist/index.js",
   "license": "BSD-3",

--- a/src/dfuTrigger.js
+++ b/src/dfuTrigger.js
@@ -81,6 +81,7 @@ const openDecorator = decoratee => (...args) => {
  *
  * @param {Device} usbdev Instance of USB's Device
  * @param {number} interfaceNumber 0-indexed interface number to check
+ * @returns {undefined}
  */
 function assertDfuTriggerInterface(usbdev, interfaceNumber) {
     if (!(usbdev.interfaces instanceof Array)) {
@@ -172,7 +173,7 @@ const sendDetachRequest = openDecorator((usbdev, interfaceNumber) => (
         debug('Sending DFU detach request ');
         usbdev.controlTransfer(
             ReqTypeOUT, DFU_DETACH_REQUEST, 0, interfaceNumber, detachReqBuf,
-            (err, data) => {
+            err => {
                 debug(`Releasing interface ${interfaceNumber}`);
                 usbdev.interfaces[interfaceNumber].release(err2 => {
                     if (err2) { reject(err2); }
@@ -211,6 +212,7 @@ const sendDetachRequest = openDecorator((usbdev, interfaceNumber) => (
 export function detach(usbdev, timeout = 5000) {
     debug('detach', timeout);
     return new Promise((resolve, reject) => {
+        let timeoutId;
         function checkDetachment(detachedDev) {
             if (usbdev === detachedDev) {
                 debug('Detachment successful');
@@ -220,7 +222,7 @@ export function detach(usbdev, timeout = 5000) {
             }
         }
 
-        const timeoutId = setTimeout(() => {
+        timeoutId = setTimeout(() => {
             debug('Timeout when waiting for USB detach event');
             usb.removeListener('detach', checkDetachment);
             reject(new Error('USB detach request sent, timeout while waiting for device reboot'));

--- a/src/setupDevice.js
+++ b/src/setupDevice.js
@@ -210,13 +210,13 @@ async function validateSerialPort(device, needSerialport) {
     for (let i = 10; i > 1; i -= 1) {
         /* eslint-disable no-await-in-loop */
         await sleep(2000 / i);
-        debug('validating seriaport', device.serialport.comName, i);
+        debug('validating serialport', device.serialport.comName, i);
         if (await checkOpen(device.serialport.comName)) {
             debug('resolving', device);
             return device;
         }
     }
-    throw new Error('couldn`t open seriaport');
+    throw new Error('couldn`t open serialport');
 }
 
 /**

--- a/src/setupDevice.js
+++ b/src/setupDevice.js
@@ -32,6 +32,7 @@
 import fs from 'fs';
 import { createHash } from 'crypto';
 import Debug from 'debug';
+import SerialPort from 'serialport';
 
 import DeviceLister from 'nrf-device-lister';
 import MemoryMap from 'nrf-intel-hex';
@@ -188,6 +189,37 @@ function parseFirmwareImage(firmware) {
 }
 
 /**
+ * Ensures that device has a serialport that is ready to be opened
+ * @param {object} device nrf-device-lister's device
+ * @param {boolean} needSerialport indicates if the device is expected to have a serialport
+ * @returns {Promise} resolved to device
+ */
+async function validateSerialPort(device, needSerialport) {
+    if (!needSerialport) {
+        debug('device doesn`t need serialport');
+        return device;
+    }
+
+    const checkOpen = comName => new Promise(resolve => {
+        const port = new SerialPort(comName, { baudRate: 115200 }, err => {
+            if (!err) port.close();
+            resolve(!err);
+        });
+    });
+
+    for (let i = 10; i > 1; i -= 1) {
+        /* eslint-disable no-await-in-loop */
+        await sleep(2000 / i);
+        debug('validating seriaport', device.serialport.comName, i);
+        if (await checkOpen(device.serialport.comName)) {
+            debug('resolving', device);
+            return device;
+        }
+    }
+    throw new Error('couldn`t open seriaport');
+}
+
+/**
  * Prepares a device which is expected to be in DFU Bootlader.
  * First it loads the firmware from HEX file specified by dfu argument,
  * then performs the DFU operation.
@@ -312,9 +344,10 @@ export function setupDevice(selectedDevice, options) {
                         return choices.pop();
                     })
                     .then(choice => prepareInDFUBootloader(selectedDevice, dfu[choice]))
-                    .then(data => {
-                        debug('DFU finished: ', data);
-                        resolve(data);
+                    .then(device => validateSerialPort(device, needSerialport))
+                    .then(device => {
+                        debug('DFU finished: ', device);
+                        resolve(device);
                     })
                     .catch(err => {
                         debug('DFU failed: ', err);
@@ -362,9 +395,10 @@ export function setupDevice(selectedDevice, options) {
                                 .then(({ device, choice }) => (
                                     prepareInDFUBootloader(device, dfu[choice])
                                 ))
-                                .then(data => {
-                                    debug('DFU finished: ', data);
-                                    resolve(data);
+                                .then(device => validateSerialPort(device, needSerialport))
+                                .then(device => {
+                                    debug('DFU finished: ', device);
+                                    resolve(device);
                                 })
                                 .catch(err => {
                                     debug('DFU failed: ', err);


### PR DESCRIPTION
Due to an issue described in [serialport](https://github.com/node-serialport/node-serialport/issues/1565) the stability of apps using this module is much better if we ensure that the resulting device after DFU does provide a serialport which can be opened immediately.
