### PR TITLE
Increase wait time for device to show up, move timeout value to constant

### DIFF
--- a/src/setupDevice.js
+++ b/src/setupDevice.js
@@ -44,7 +44,7 @@ import * as jprogFunc from './jprogFunc';
 /** 
  * @const {number} DEFAULT_DEVICE_WAIT_TIME Default wait time for UART port to show up in operating system
  */
-const DEFAULT_DEVICE_WAIT_TIME = 6000;
+const DEFAULT_DEVICE_WAIT_TIME = 10000;
 
 const {
     getDFUInterfaceNumber,


### PR DESCRIPTION
The wait time for a PCA10059 UART to show up on my machine (Windows 10) was too short (5 seconds).
Increasing this value to 6 seconds make it work consistently on my machine.

Moved the wait time into a constant.