### PR TITLE
Bumped version to 0.2.8, dfu to 0.2.4, pinned jprog

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nrf-device-setup",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Common USB/serialport/jlink device actions to check/program nRF devices",
   "main": "dist/index.js",
   "license": "BSD-3",
@@ -21,8 +21,8 @@
     "immutable": "^3.8.2",
     "nrf-device-lister": "^2.0.0",
     "nrf-intel-hex": "^1.3.0",
-    "pc-nrf-dfu-js": "^0.2.3",
-    "pc-nrfjprog-js": "^1.2.0",
+    "pc-nrf-dfu-js": "^0.2.4",
+    "pc-nrfjprog-js": "1.2.0",
     "protobufjs": "^6.8.6",
     "serialport": "^6.2.0",
     "usb": "^1.3.1"


### PR DESCRIPTION
pc-nrf-jprog-js reverted to 1.2.0 for jprog 9.7.1 dependency until 9.7.4 comes.