### PR TITLE
Close jlink on setup failure

### DIFF
--- a/src/setupDevice.js
+++ b/src/setupDevice.js
@@ -41,7 +41,7 @@ import * as initPacket from './util/initPacket';
 import * as dfuTrigger from './dfuTrigger';
 import * as jprogFunc from './jprogFunc';
 
-/** 
+/**
  * @const {number} DEFAULT_DEVICE_WAIT_TIME Default wait time for UART port to show up in operating system
  */
 const DEFAULT_DEVICE_WAIT_TIME = 10000;
@@ -441,9 +441,10 @@ export function setupDevice(selectedDevice, options) {
                         })
                         .then(() => programFirmware(selectedDevice, firmwareFamily));
                 })
-                .then(() => closeJLink(selectedDevice))
-                .then(() => resolve(selectedDevice))
-                .catch(reject);
+                .then(
+                    () => { return closeJLink(selectedDevice).then(() => {resolve(selectedDevice)}) },
+                    err => closeJLink(selectedDevice).then(() => { reject(err); })
+                );
         }
 
         debug('Selected device cannot be prepared, maybe the app still can use it');


### PR DESCRIPTION
This covers a case where trying to setup a device for which device is not defined for its family, due to the jlink instance not being closed.

Also removing one level of indentation and promise wrapping - that removes spurious `resolve()` calls and makes the code a tiny bit more comprehensible IMHO.