### PR TITLE
Added dfu-cc.js to .eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+src/util/dfu-cc.js


### PR DESCRIPTION
In order to successfully call `npm run lint` we need to skip generated source file.