### PR TITLE
Remove dependencies that are installed by nrf-device-lister

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,17 +24,12 @@
     "dfu-trigger": "./bin/dfu-trigger.js"
   },
   "dependencies": {
-    "commander": "^2.19.0",
-    "debug": "^3.1.0",
     "immutable": "^3.8.2",
     "inquirer": "^5.1.0",
     "nrf-device-lister": "^2.1.1",
     "nrf-intel-hex": "^1.3.0",
-    "usb": "git+https://github.com/NordicPlayground/node-usb.git#semver:^1.5.0",
     "pc-nrf-dfu-js": "^0.2.6",
-    "pc-nrfjprog-js": "^1.4.4",
-    "protobufjs": "^6.8.6",
-    "serialport": "^6.2.0"
+    "protobufjs": "^6.8.6"
   },
   "devDependencies": {
     "eslint": "^4.16.0",


### PR DESCRIPTION
This PR removes dependencies that get installed anyway as dependecies of _nrf-device-lister_ module in order to avoid unnecessary dependency resolution conflicts in projects where both modules are used.
