### PR TITLE
Add 91 family, enhance firmware definition configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,19 @@ const configuration = {
 
 For JLink devices _pc-nrfjprog-js_ is used to check for `fwVersion` at `fwIdAddress`, and
 in case of a mismatch the referenced `fw` is flashed to the device. These values are grouped
-under the device family key, which can be either `nrf51` or `nrf52`.
+under the device type or board version or family key which is resolved by specificity.
+The keys are case-insensitive.
 ```js
 configuration.jprog = {
+    NRF52832_xxAA_REV2: {...},
+
+    // fallback if exact device type not specified
+    NRF52832: {...},
+
+    // fallback if device type not specified
+    PCA10040: {...},
+
+    // fallback to family if board version not specified
     nrf52: {
         fw: path.resolve(__dirname, 'fw/customfirmware-for-nrf52.hex'),
 
@@ -98,6 +108,7 @@ configuration.jprog = {
 
         fwIdAddress: 0x2000,
     },
+
     nrf51: {...},
 }
 ```

--- a/src/setupDevice.js
+++ b/src/setupDevice.js
@@ -554,7 +554,6 @@ export function setupDevice(selectedDevice, options) {
 
 
     if (jprog && selectedDevice.traits.includes('jlink')) {
-        // let firmwareFamily;
         let wasProgrammed = false;
         return Promise.resolve()
             .then(() => needSerialport && verifySerialPortAvailable(selectedDevice))

--- a/src/setupDevice.js
+++ b/src/setupDevice.js
@@ -66,7 +66,7 @@ const {
     openJLink,
     closeJLink,
     verifySerialPortAvailable,
-    getDeviceFamily,
+    getDeviceInfo,
     validateFirmware,
     programFirmware,
 } = jprogFunc;
@@ -554,25 +554,38 @@ export function setupDevice(selectedDevice, options) {
 
 
     if (jprog && selectedDevice.traits.includes('jlink')) {
-        let firmwareFamily;
+        // let firmwareFamily;
         let wasProgrammed = false;
         return Promise.resolve()
             .then(() => needSerialport && verifySerialPortAvailable(selectedDevice))
             .then(() => openJLink(selectedDevice))
-            .then(() => getDeviceFamily(selectedDevice))
-            .then(family => {
-                const { boardVersion } = selectedDevice;
-                firmwareFamily = jprog[boardVersion.toLowerCase()];
-                if (!firmwareFamily) {
-                    debug(`No specific firmware for board ${boardVersion}.`);
-                    firmwareFamily = jprog[family];
-                    if (!firmwareFamily) {
-                        throw new Error(`No firmware defined for ${family} family or board version ${boardVersion}`);
-                    }
+            .then(() => getDeviceInfo(selectedDevice))
+            .then(deviceInfo => {
+                Object.assign(selectedDevice, { deviceInfo });
+
+                const family = (deviceInfo.family || '').toLowerCase();
+                const deviceType = (deviceInfo.deviceType || '').toLowerCase();
+                const shortDeviceType = deviceType.split('_').shift();
+                const boardVersion = (selectedDevice.boardVersion || '').toLowerCase();
+
+                const key = Object.keys(jprog).find(k => k.toLowerCase() === deviceType)
+                    || Object.keys(jprog).find(k => k.toLowerCase() === shortDeviceType)
+                    || Object.keys(jprog).find(k => k.toLowerCase() === boardVersion)
+                    || Object.keys(jprog).find(k => k.toLowerCase() === family);
+
+                if (!key) {
+                    throw new Error('No firmware defined for selected device');
                 }
+                debug('Found matching firmware definition', key);
+                return jprog[key];
             })
-            .then(() => validateFirmware(selectedDevice, firmwareFamily))
-            .then(valid => {
+            .then(firmwareDefinition => (
+                {
+                    valid: validateFirmware(selectedDevice, firmwareDefinition),
+                    firmwareDefinition,
+                }
+            ))
+            .then((valid, firmwareDefinition) => {
                 if (valid) {
                     debug('Application firmware id matches');
                     return selectedDevice;
@@ -583,7 +596,7 @@ export function setupDevice(selectedDevice, options) {
                             // go on without update
                             return selectedDevice;
                         }
-                        return programFirmware(selectedDevice, firmwareFamily)
+                        return programFirmware(selectedDevice, firmwareDefinition)
                             .then(() => {
                                 wasProgrammed = true;
                             });
@@ -599,6 +612,7 @@ export function setupDevice(selectedDevice, options) {
     debug('Selected device cannot be prepared, maybe the app still can use it');
     return Promise.resolve(createReturnValue(
         selectedDevice,
-        { wasProgrammed: false }, detailedOutput,
+        { wasProgrammed: false },
+        detailedOutput,
     ));
 }


### PR DESCRIPTION
This PR adds nrf91 family along with all known specific and shortened device ids to possible configuration keys, which are resolved in order of specificity to pick matching firmware definition from the configuration.
Also added _deviceInfo_ object to _selectedDevice_ in order to potentially speed up apps that would query for this later.