### PR TITLE
Upgrade serialport

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,3 +218,7 @@ The project comes with automated integration tests in the `test` directory. In o
 To run tests for only one device type, include the name of the test file e.g.
 
     npm test -- nrf51
+
+To include the tests for the nRF52840 dongle, you have to set the environment variable `DONGLE_SERIAL_NUMBER` to the serial number of your dongle e.g.
+
+    DONGLE_SERIAL_NUMBER=E5530B54CD8C npm test

--- a/bin/device-setup.js
+++ b/bin/device-setup.js
@@ -93,7 +93,7 @@ function chooseDevice() {
                 const type = Object.keys(traits).find(e => Object.keys(device).includes(e));
                 choices.push({
                     key: serialNumber.toString(),
-                    name: `${serialNumber}: (${device.serialport.comName}) ${device[type].manufacturer} / ${device[type].product || device[type].productId}`,
+                    name: `${serialNumber}: (${device.serialport.path}) ${device[type].manufacturer} / ${device[type].product || device[type].productId}`,
                     value: serialNumber,
                 });
             });

--- a/bin/dfu-trigger.js
+++ b/bin/dfu-trigger.js
@@ -72,7 +72,7 @@ function chooseDevice() {
                 const type = Object.keys(traits).find(e => Object.keys(device).includes(e));
                 choices.push({
                     key: serialNumber.toString(),
-                    name: `${serialNumber}: (${device.serialport.comName}) ${device[type].manufacturer} / ${device[type].product || device[type].productId}`,
+                    name: `${serialNumber}: (${device.serialport.path}) ${device[type].manufacturer} / ${device[type].product || device[type].productId}`,
                     value: serialNumber,
                 });
             });

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "immutable": "^4.0.0-rc.12",
     "inquirer": "^6.4.1",
-    "nrf-device-lister": "^2.3.1",
+    "nrf-device-lister": "^2.4.0",
     "nrf-intel-hex": "^1.3.0",
     "pc-nrf-dfu-js": "^0.2.9",
     "protobufjs": "^6.8.8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nrf-device-setup",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "Common USB/serialport/jlink device actions to check/program nRF devices",
   "main": "dist/index.js",
   "license": "BSD-3",

--- a/src/dfuTrigger.js
+++ b/src/dfuTrigger.js
@@ -93,9 +93,9 @@ function assertDfuTriggerInterface(usbdev, interfaceNumber) {
         throw new Error(`Interface number ${interfaceNumber} does not exist on USB device; cannot perform DFU trigger operation.`);
     }
 
-    if (iface.descriptor.bInterfaceClass !== 255 ||
-        iface.descriptor.bInterfaceSubClass !== 1 ||
-        iface.descriptor.bInterfaceProtocol !== 1
+    if (iface.descriptor.bInterfaceClass !== 255
+        || iface.descriptor.bInterfaceSubClass !== 1
+        || iface.descriptor.bInterfaceProtocol !== 1
     ) {
         throw new Error(`Interface number ${interfaceNumber} does not look like a DFU trigger interface; cannot perform DFU trigger operation.`);
     }
@@ -113,9 +113,9 @@ function getDFUInterfaceNumber(usbdev) {
     }
 
     const dfuTriggerInterface = usbdev.interfaces.findIndex(iface => (
-        iface.descriptor.bInterfaceClass === 255 &&
-        iface.descriptor.bInterfaceSubClass === 1 &&
-        iface.descriptor.bInterfaceProtocol === 1
+        iface.descriptor.bInterfaceClass === 255
+        && iface.descriptor.bInterfaceSubClass === 1
+        && iface.descriptor.bInterfaceProtocol === 1
     ));
 
     if (wasClosed) {
@@ -184,13 +184,13 @@ const sendDetachRequest = openDecorator((usbdev, interfaceNumber) => (
                     // so the expected result is that the control transfer will stall.
                     // On MacOS, DFU detach request does not stall as on Windows.
                     // Just regard it as detaching successfully.
-                    if (err &&
-                        err.errno === usb.LIBUSB_TRANSFER_STALL &&
-                        err.message === 'LIBUSB_TRANSFER_STALL') {
+                    if (err
+                        && err.errno === usb.LIBUSB_TRANSFER_STALL
+                        && err.message === 'LIBUSB_TRANSFER_STALL') {
                         resolve();
-                    } else if (err &&
-                        err.errno === usb.LIBUSB_ERROR_IO &&
-                        err.message === 'LIBUSB_ERROR_IO') {
+                    } else if (err
+                        && err.errno === usb.LIBUSB_ERROR_IO
+                        && err.message === 'LIBUSB_ERROR_IO') {
                         // This edge case only happens when using the "libusb" kernel
                         // driver on win32 (not "winusb", not "libusbk")
                         resolve();

--- a/src/jprogFunc.js
+++ b/src/jprogFunc.js
@@ -170,7 +170,7 @@ function verifySerialPortAvailable(device) {
             + `serial number ${device.serialNumber}`));
     }
     return new Promise((resolve, reject) => {
-        const serialPort = new SerialPort(device.serialport.comName, { autoOpen: false });
+        const serialPort = new SerialPort(device.serialport.path, { autoOpen: false });
         serialPort.open(openErr => {
             if (openErr) {
                 reject(openErr);

--- a/src/setupDevice.js
+++ b/src/setupDevice.js
@@ -210,8 +210,8 @@ async function validateSerialPort(device, needSerialport) {
         return device;
     }
 
-    const checkOpen = path => new Promise(resolve => {
-        const port = new SerialPort(path, { baudRate: 115200 }, err => {
+    const checkOpen = serialPath => new Promise(resolve => {
+        const port = new SerialPort(serialPath, { baudRate: 115200 }, err => {
             if (!err) port.close();
             resolve(!err);
         });
@@ -241,8 +241,7 @@ async function validateSerialPort(device, needSerialport) {
  * @returns {Promise} resolved to prepared device
  */
 async function prepareInDFUBootloader(device, dfu) {
-    const { path } = device.serialport;
-    debug(`${device.serialNumber} on ${path} is now in DFU-Bootloader...`);
+    debug(`${device.serialNumber} on ${device.serialport.path} is now in DFU-Bootloader...`);
 
     const { application, softdevice } = dfu;
     let { params } = dfu;
@@ -346,8 +345,7 @@ async function getBootloaderVersion(device) {
  * @returns {Promise<Object>} device object after dfu is completed and device is enumerated again.
  */
 async function updateBootloader(device) {
-    const { path } = device.serialport;
-    debug(`Bootloader for device ${device.serialNumber} on ${path} will be updated`);
+    debug(`Bootloader for device ${device.serialNumber} on ${device.serialport.path} will be updated`);
 
     const updates = await DfuUpdates.fromZipFilePath(LATEST_BOOTLOADER_PATH);
     const usbSerialTransport = new DfuTransportUsbSerial(device.serialNumber, 0);

--- a/src/setupDevice.js
+++ b/src/setupDevice.js
@@ -210,8 +210,8 @@ async function validateSerialPort(device, needSerialport) {
         return device;
     }
 
-    const checkOpen = comName => new Promise(resolve => {
-        const port = new SerialPort(comName, { baudRate: 115200 }, err => {
+    const checkOpen = path => new Promise(resolve => {
+        const port = new SerialPort(path, { baudRate: 115200 }, err => {
             if (!err) port.close();
             resolve(!err);
         });
@@ -220,9 +220,9 @@ async function validateSerialPort(device, needSerialport) {
     for (let i = 10; i > 1; i -= 1) {
         /* eslint-disable-next-line no-await-in-loop */
         await sleep(2000 / i);
-        debug('validating serialport', device.serialport.comName, i);
+        debug('validating serialport', device.serialport.path, i);
         /* eslint-disable-next-line no-await-in-loop */
-        if (await checkOpen(device.serialport.comName)) {
+        if (await checkOpen(device.serialport.path)) {
             debug('resolving', device);
             return device;
         }
@@ -241,8 +241,8 @@ async function validateSerialPort(device, needSerialport) {
  * @returns {Promise} resolved to prepared device
  */
 async function prepareInDFUBootloader(device, dfu) {
-    const { comName } = device.serialport;
-    debug(`${device.serialNumber} on ${comName} is now in DFU-Bootloader...`);
+    const { path } = device.serialport;
+    debug(`${device.serialNumber} on ${path} is now in DFU-Bootloader...`);
 
     const { application, softdevice } = dfu;
     let { params } = dfu;
@@ -346,8 +346,8 @@ async function getBootloaderVersion(device) {
  * @returns {Promise<Object>} device object after dfu is completed and device is enumerated again.
  */
 async function updateBootloader(device) {
-    const { comName } = device.serialport;
-    debug(`Bootloader for device ${device.serialNumber} on ${comName} will be updated`);
+    const { path } = device.serialport;
+    debug(`Bootloader for device ${device.serialNumber} on ${path} will be updated`);
 
     const updates = await DfuUpdates.fromZipFilePath(LATEST_BOOTLOADER_PATH);
     const usbSerialTransport = new DfuTransportUsbSerial(device.serialNumber, 0);

--- a/src/util/initPacket.js
+++ b/src/util/initPacket.js
@@ -196,8 +196,8 @@ export function createResetPacket(timeout, signatureType, signature) {
         }
 
         // It checks both null and undefined here
-        if ((signatureType == null && signature != null) ||
-            (signatureType != null && signature == null)) {
+        if ((signatureType == null && signature != null)
+            || (signatureType != null && signature == null)) {
             throw new Error('Either signature type or signature is not set');
         }
 
@@ -272,8 +272,8 @@ export function createInitPacket(
 ) {
     try {
         // It checks both null and undefined here
-        if ((signatureType == null && signature != null) ||
-            (signatureType != null && signature == null)) {
+        if ((signatureType == null && signature != null)
+            || (signatureType != null && signature == null)) {
             throw new Error('Either signature type or signature is not set');
         }
 


### PR DESCRIPTION
Part of [NCP-2996](https://projecttools.nordicsemi.no/jira/browse/NCP-2996).

Upgraded the nrf-device-lister dependency. The main change from this is the upgraded serialport dependency, which renames the property `comName` to `path`.

Also added a description how to test with a nRF52840 dongle and fixed linting errors.